### PR TITLE
デフォルトでは大文字小文字を無視しないように変更

### DIFF
--- a/token.go
+++ b/token.go
@@ -17,10 +17,10 @@ func (b *bigram) String() string {
 func Biunigrams(s string) []string {
 	tokens := make([]string, 0, 32)
 
-	for bigram := range toBigrams(strings.ToLower(s)) {
+	for bigram := range toBigrams(s) {
 		tokens = append(tokens, fmt.Sprintf("%c%c", bigram.a, bigram.b))
 	}
-	for unigram := range toUnigrams(strings.ToLower(s)) {
+	for unigram := range toUnigrams(s) {
 		tokens = append(tokens, fmt.Sprintf("%c", unigram))
 	}
 
@@ -31,7 +31,7 @@ func Biunigrams(s string) []string {
 func Bigrams(s string) []string {
 	tokens := make([]string, 0, 32)
 
-	for bigram := range toBigrams(strings.ToLower(s)) {
+	for bigram := range toBigrams(s) {
 		tokens = append(tokens, fmt.Sprintf("%c%c", bigram.a, bigram.b))
 	}
 
@@ -44,7 +44,7 @@ func Prefixes(s string) []string {
 
 	runes := make([]rune, 0, 64)
 
-	for _, w := range strings.Split(strings.ToLower(s), " ") {
+	for _, w := range strings.Split(s, " ") {
 		if w == "" {
 			continue
 		}
@@ -69,7 +69,7 @@ func Prefixes(s string) []string {
 func toBigrams(value string) map[bigram]bool {
 	result := make(map[bigram]bool)
 	var prev rune
-	for i, r := range strings.ToLower(value) {
+	for i, r := range value {
 		if i > 0 && prev != ' ' && r != ' ' {
 			result[bigram{prev, r}] = true
 		}
@@ -80,7 +80,7 @@ func toBigrams(value string) map[bigram]bool {
 
 func toUnigrams(value string) map[rune]bool {
 	result := make(map[rune]bool)
-	for _, r := range strings.ToLower(value) {
+	for _, r := range value {
 		if r == ' ' {
 			continue
 		}

--- a/token_test.go
+++ b/token_test.go
@@ -13,8 +13,8 @@ func TestString(t *testing.T) {
 
 func TestToUnigrams(t *testing.T) {
 	result := toUnigrams("abc dあいbCh")
-	if len(result) != 7 {
-		t.Errorf("len(result) exected:%d, but was:%d\n", 7, len(result))
+	if len(result) != 8 {
+		t.Errorf("len(result) exected:%d, but was:%d\n", 8, len(result))
 	}
 
 	if !result['a'] {
@@ -25,6 +25,9 @@ func TestToUnigrams(t *testing.T) {
 	}
 	if !result['c'] {
 		t.Errorf("Unigrbm notfound. 'c'")
+	}
+	if !result['C'] {
+		t.Errorf("Unigrbm notfound. 'C'")
 	}
 	if !result['d'] {
 		t.Errorf("Unigrbm notfound. 'd'")
@@ -51,10 +54,10 @@ func TestToBigrams(t *testing.T) {
 	assertBigram(t, result, bigram{'d', 'e'})
 	assertBigram(t, result, bigram{'e', 'b'})
 	assertBigram(t, result, bigram{'c', 'h'})
-	assertBigram(t, result, bigram{'i', 'j'})
-	assertBigram(t, result, bigram{'j', 'あ'})
+	assertBigram(t, result, bigram{'i', 'J'})
+	assertBigram(t, result, bigram{'J', 'あ'})
 	assertBigram(t, result, bigram{'あ', 'd'})
-	assertBigram(t, result, bigram{'e', 'n'})
+	assertBigram(t, result, bigram{'e', 'N'})
 }
 
 func assertBigram(t *testing.T, set map[bigram]bool, bigram bigram) {

--- a/xian_test.go
+++ b/xian_test.go
@@ -7,41 +7,44 @@ import (
 
 func TestBiunigrams(t *testing.T) {
 	result := Biunigrams("abc dあいbCh")
-	if len(result) != 13 {
+	if len(result) != 15 {
 		t.Errorf("len(result) exected:%d, but was:%d\n", 13, len(result))
 	}
 
 	sort.Strings(result)
 
-	assert(t, "result[0]", result[0], "a")
-	assert(t, "result[1]", result[1], "ab")
-	assert(t, "result[2]", result[2], "b")
-	assert(t, "result[3]", result[3], "bc")
-	assert(t, "result[4]", result[4], "c")
-	assert(t, "result[5]", result[5], "ch")
-	assert(t, "result[6]", result[6], "d")
-	assert(t, "result[7]", result[7], "dあ")
-	assert(t, "result[8]", result[8], "h")
-	assert(t, "result[9]", result[9], "あ")
-	assert(t, "result[10]", result[10], "あい")
-	assert(t, "result[11]", result[11], "い")
-	assert(t, "result[12]", result[12], "いb")
+	assert(t, "result[0]", result[0], "C")
+	assert(t, "result[1]", result[1], "Ch")
+	assert(t, "result[2]", result[2], "a")
+	assert(t, "result[3]", result[3], "ab")
+	assert(t, "result[4]", result[4], "b")
+	assert(t, "result[5]", result[5], "bC")
+	assert(t, "result[6]", result[6], "bc")
+	assert(t, "result[7]", result[7], "c")
+	assert(t, "result[8]", result[8], "d")
+	assert(t, "result[9]", result[9], "dあ")
+	assert(t, "result[10]", result[10], "h")
+	assert(t, "result[11]", result[11], "あ")
+	assert(t, "result[12]", result[12], "あい")
+	assert(t, "result[13]", result[13], "い")
+	assert(t, "result[14]", result[14], "いb")
 }
 
 func TestBigrams(t *testing.T) {
 	result := Bigrams("abc dあいbCh")
-	if len(result) != 6 {
+	if len(result) != 7 {
 		t.Errorf("len(result) exected:%d, but was:%d\n", 6, len(result))
 	}
 
 	sort.Strings(result)
 
-	assert(t, "result[0]", result[0], "ab")
-	assert(t, "result[1]", result[1], "bc")
-	assert(t, "result[2]", result[2], "ch")
-	assert(t, "result[3]", result[3], "dあ")
-	assert(t, "result[4]", result[4], "あい")
-	assert(t, "result[5]", result[5], "いb")
+	assert(t, "result[0]", result[0], "Ch")
+	assert(t, "result[1]", result[1], "ab")
+	assert(t, "result[2]", result[2], "bC")
+	assert(t, "result[3]", result[3], "bc")
+	assert(t, "result[4]", result[4], "dあ")
+	assert(t, "result[5]", result[5], "あい")
+	assert(t, "result[6]", result[6], "いb")
 }
 
 func TestPrefixes(t *testing.T) {
@@ -59,8 +62,8 @@ func TestPrefixes(t *testing.T) {
 	assert(t, "result[4]", result[4], "dあ")
 	assert(t, "result[5]", result[5], "dあい")
 	assert(t, "result[6]", result[6], "dあいb")
-	assert(t, "result[7]", result[7], "dあいbc")
-	assert(t, "result[8]", result[8], "dあいbch")
+	assert(t, "result[7]", result[7], "dあいbC")
+	assert(t, "result[8]", result[8], "dあいbCh")
 }
 
 func assert(t *testing.T, title string, actual, expected interface{}) {


### PR DESCRIPTION
各処理の strings.ToLower を削除