### PR TITLE
Economize size when using `time.Time` with AddSomethingXXX

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -78,7 +78,7 @@ func (filters *Filters) AddSomething(label string, indexes interface{}) *Filters
 			filters.Add(label, fmt.Sprintf("%v", v.Index(i).Interface()))
 		}
 	case timeKind:
-		unix := v.Interface().(time.Time).Unix()
+		unix := v.Interface().(time.Time).UnixNano()
 		filters.Add(label, fmt.Sprintf("%d", unix))
 	default:
 		filters.Add(label, fmt.Sprintf("%v", v.Interface()))

--- a/filters.go
+++ b/filters.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/pkg/errors"
@@ -76,6 +77,9 @@ func (filters *Filters) AddSomething(label string, indexes interface{}) *Filters
 		for i := 0; i < v.Len(); i++ {
 			filters.Add(label, fmt.Sprintf("%v", v.Index(i).Interface()))
 		}
+	case timeKind:
+		unix := v.Interface().(time.Time).Unix()
+		filters.Add(label, fmt.Sprintf("%d", unix))
 	default:
 		filters.Add(label, fmt.Sprintf("%v", v.Interface()))
 	}

--- a/filters_test.go
+++ b/filters_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 )
 
 func TestAddFilter(t *testing.T) {
@@ -87,12 +88,15 @@ func TestAddSomethingFilter(t *testing.T) {
 	filter := NewFilters(nil)
 	filter.AddSomething("label1", []string{"abc dあいbCh", "abc debch iJあdeN"})
 	filter.AddSomething("label2", 123)
+	now := time.Now()
+	filter.AddSomething("label3", now)
 
 	built := filter.MustBuild()
 	assertBuiltFilter(t, built, []string{
 		"label1 abc dあいbCh",
 		"label1 abc debch iJあdeN",
 		"label2 123",
+		fmt.Sprintf("label3 %d", now.Unix()),
 	})
 }
 

--- a/filters_test.go
+++ b/filters_test.go
@@ -96,7 +96,7 @@ func TestAddSomethingFilter(t *testing.T) {
 		"label1 abc dあいbCh",
 		"label1 abc debch iJあdeN",
 		"label2 123",
-		fmt.Sprintf("label3 %d", now.Unix()),
+		fmt.Sprintf("label3 %d", now.UnixNano()),
 	})
 }
 

--- a/indexes.go
+++ b/indexes.go
@@ -71,7 +71,7 @@ func (idxs *Indexes) AddSomething(label string, indexes interface{}) *Indexes {
 			idxs.Add(label, fmt.Sprintf("%v", v.Index(i).Interface()))
 		}
 	case timeKind:
-		unix := v.Interface().(time.Time).Unix()
+		unix := v.Interface().(time.Time).UnixNano()
 		idxs.Add(label, fmt.Sprintf("%d", unix))
 	default:
 		idxs.Add(label, fmt.Sprintf("%v", v.Interface()))

--- a/indexes.go
+++ b/indexes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -69,6 +70,9 @@ func (idxs *Indexes) AddSomething(label string, indexes interface{}) *Indexes {
 		for i := 0; i < v.Len(); i++ {
 			idxs.Add(label, fmt.Sprintf("%v", v.Index(i).Interface()))
 		}
+	case timeKind:
+		unix := v.Interface().(time.Time).Unix()
+		idxs.Add(label, fmt.Sprintf("%d", unix))
 	default:
 		idxs.Add(label, fmt.Sprintf("%v", v.Interface()))
 	}

--- a/indexes_test.go
+++ b/indexes_test.go
@@ -85,7 +85,7 @@ func TestAddSomethingIndex(t *testing.T) {
 		"label1 abc dあいbCh",
 		"label1 abc debch iJあdeN",
 		"label2 123",
-		fmt.Sprintf("label3 %d", now.Unix()),
+		fmt.Sprintf("label3 %d", now.UnixNano()),
 	})
 }
 

--- a/indexes_test.go
+++ b/indexes_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 )
 
 func TestAddIndex(t *testing.T) {
@@ -76,12 +77,15 @@ func TestAddSomethingIndex(t *testing.T) {
 	idx := NewIndexes(nil)
 	idx.AddSomething("label1", []string{"abc dあいbCh", "abc debch iJあdeN"})
 	idx.AddSomething("label2", 123)
+	now := time.Now()
+	idx.AddSomething("label3", now)
 
 	built := idx.MustBuild()
 	assertBuiltIndex(t, built, []string{
 		"label1 abc dあいbCh",
 		"label1 abc debch iJあdeN",
 		"label2 123",
+		fmt.Sprintf("label3 %d", now.Unix()),
 	})
 }
 

--- a/xian.go
+++ b/xian.go
@@ -3,7 +3,9 @@ package xian
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -33,6 +35,8 @@ type Config struct {
 
 // DefaultConfig is default configuration.
 var DefaultConfig = &Config{}
+
+var timeKind = reflect.TypeOf(time.Time{}).Kind()
 
 // ValidateConfig validates Config fields.
 func ValidateConfig(conf *Config) (*Config, error) {


### PR DESCRIPTION
ex:
`2009-11-10 23:00:00 +0000 UTC m=+0.000000001`
↓
`1257894000000000000 `